### PR TITLE
Investigate npm publish version conflict

### DIFF
--- a/.github/workflows/publish-contract.yml
+++ b/.github/workflows/publish-contract.yml
@@ -2,14 +2,14 @@
 name: Publish API Contract to GitHub Packages
 
 on:
-  push:
-    paths:
-      - 'src/**/*.ts'
-      - 'dist/**/*.d.ts'
-      - 'package.json'
+  workflow_run:
+    workflows: ["Update Version"]
+    types:
+      - completed
 
 jobs:
   publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -30,24 +31,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump version if needed
-        run: |
-          latest=$(npm view @tobenot/basic-web-game-backend-contract version --registry=https://npm.pkg.github.com || echo "0.0.0")
-          current=$(node -p "require('./package.json').version")
-          if [ "$current" = "$latest" ]; then
-            next=$(npx semver $latest -i patch)
-            jq ".version = \"$next\"" package.json > package.json.tmp && mv package.json.tmp package.json
-            echo "Bumped version to $next"
-          else
-            echo "No need to bump version"
-          fi
-
       - name: Build
         run: npm run build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Skip if version already exists
+        id: precheck
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Local version: $VERSION"
+          if npm view @tobenot/basic-web-game-backend-contract@${VERSION} version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already exists in registry. Skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish package
+        if: steps.precheck.outputs.exists == 'false'
         run: npm publish --registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,17 +28,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@tobenot'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version
-        run: npm run version:${{ github.event.inputs.version_type }}
+        run: REGISTRY_URL=https://npm.pkg.github.com NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run version:${{ github.event.inputs.version_type }}
 
       - name: Commit and push version update
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json
-          git commit -m "Update version to ${{ github.event.inputs.version_type }}"
-          git push
+          git add package.json package-lock.json || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: version bump (${{ github.event.inputs.version_type }})"
+            git push
+          fi

--- a/VERSION_MANAGEMENT.md
+++ b/VERSION_MANAGEMENT.md
@@ -47,12 +47,12 @@ npm run get-next-version
 
 修改后的发布流程：
 1. 手动更新版本号（本地或GitHub Action）
-2. 推送到main分支
-3. 自动触发发布到npm包（不会更新版本号）
+2. 推送到 main 分支
+3. “Update Version” 工作流成功后，自动触发发布工作流，将当前主分支代码发布到 GitHub Packages（发布流程本身不会修改版本号）
 
 ### 5. 避免循环触发
 
-- 发布工作流添加了`paths-ignore: ['package.json']`，避免版本更新触发发布
+- 发布工作流不再基于 push 触发，而是仅在“Update Version”工作流成功完成后触发
 - 版本更新工作流只在手动触发时运行
 
 ## 使用建议

--- a/scripts/get-next-version.js
+++ b/scripts/get-next-version.js
@@ -1,17 +1,37 @@
 const https = require('https');
 const { execSync } = require('child_process');
 
-async function getPackageInfo(packageName) {
+function getRegistryUrl() {
+  return process.env.REGISTRY_URL || 'https://npm.pkg.github.com';
+}
+
+function getLatestVersionViaNpmView(packageName) {
+  const registryUrl = getRegistryUrl();
+  try {
+    const cmd = `npm view ${packageName} version --registry=${registryUrl}`;
+    const output = execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
+    const lines = output.split(/\r?\n/);
+    const version = lines[lines.length - 1].trim();
+    if (/^\d+\.\d+\.\d+(-.+)?$/.test(version)) {
+      return version;
+    }
+    throw new Error('Unexpected npm view output');
+  } catch (error) {
+    return null;
+  }
+}
+
+async function getPackageInfoFromNpmJs(packageName) {
   return new Promise((resolve, reject) => {
     const url = `https://registry.npmjs.org/${packageName}`;
-    
+
     https.get(url, (res) => {
       let data = '';
-      
+
       res.on('data', (chunk) => {
         data += chunk;
       });
-      
+
       res.on('end', () => {
         try {
           const packageInfo = JSON.parse(data);
@@ -28,7 +48,7 @@ async function getPackageInfo(packageName) {
 
 function incrementVersion(version, type = 'patch') {
   const parts = version.split('.').map(Number);
-  
+
   switch (type) {
     case 'major':
       parts[0]++;
@@ -44,37 +64,41 @@ function incrementVersion(version, type = 'patch') {
       parts[2]++;
       break;
   }
-  
+
   return parts.join('.');
 }
 
 async function getNextVersion(packageName, versionType = 'patch') {
   try {
-    const packageInfo = await getPackageInfo(packageName);
-    const currentVersion = packageInfo['dist-tags'].latest;
+    // 1) Prefer querying the configured registry (default GitHub Packages)
+    const latestFromConfigured = getLatestVersionViaNpmView(packageName);
+    if (latestFromConfigured) {
+      const nextVersion = incrementVersion(latestFromConfigured, versionType);
+      console.log(`Current version (registry ${getRegistryUrl()}): ${latestFromConfigured}`);
+      console.log(`Next version: ${nextVersion}`);
+      return nextVersion;
+    }
+
+    // 2) Fallback to public npmjs.org
+    try {
+      const packageInfo = await getPackageInfoFromNpmJs(packageName);
+      const currentVersion = packageInfo['dist-tags'].latest;
+      const nextVersion = incrementVersion(currentVersion, versionType);
+      console.log(`Current version (npmjs.org): ${currentVersion}`);
+      console.log(`Next version: ${nextVersion}`);
+      return nextVersion;
+    } catch (_) {}
+
+    // 3) Fallback to local package.json
+    const packageJson = require('../package.json');
+    const currentVersion = packageJson.version;
     const nextVersion = incrementVersion(currentVersion, versionType);
-    
-    console.log(`Current version: ${currentVersion}`);
+    console.log(`Using local package.json version: ${currentVersion}`);
     console.log(`Next version: ${nextVersion}`);
-    
     return nextVersion;
   } catch (error) {
-    console.error('Error fetching package info:', error.message);
-    
-    // Fallback: read from local package.json
-    try {
-      const packageJson = require('../package.json');
-      const currentVersion = packageJson.version;
-      const nextVersion = incrementVersion(currentVersion, versionType);
-      
-      console.log(`Using local package.json version: ${currentVersion}`);
-      console.log(`Next version: ${nextVersion}`);
-      
-      return nextVersion;
-    } catch (fallbackError) {
-      console.error('Error reading local package.json:', fallbackError.message);
-      process.exit(1);
-    }
+    console.error('Error determining next version:', error.message);
+    process.exit(1);
   }
 }
 
@@ -82,7 +106,7 @@ async function getNextVersion(packageName, versionType = 'patch') {
 if (require.main === module) {
   const packageName = process.argv[2] || '@tobenot/basic-web-game-backend-contract';
   const versionType = process.argv[3] || 'patch';
-  
+
   getNextVersion(packageName, versionType)
     .then(nextVersion => {
       console.log(nextVersion);


### PR DESCRIPTION
Refactor GitHub Actions to prevent 409 Conflict errors by ensuring publishes only occur after explicit version bumps and skipping if the version already exists.

The previous `publish-contract.yml` workflow was triggered on `push` to `main` for certain file changes and included an in-place version bump. This led to `npm error 409 Conflict` when a non-version-changing commit was pushed, as the workflow would attempt to publish the same version that already existed. This PR aligns the publishing with the "Update Version" workflow and adds a pre-check to avoid conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-7be75621-7fb5-4927-ad19-600b059521b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7be75621-7fb5-4927-ad19-600b059521b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

