### PR TITLE
Configure gitignore for backend archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,6 @@ vite.config.ts.timestamp-*
 
 # Deployment artifacts
 /release-*.tar.gz
-/bwb-*.tar.gz
+/basic-web-game-backend-contract-*.tar.gz
 /.release-stage/
 /deploy-packages/

--- a/deploy/pm2/ecosystem.config.js
+++ b/deploy/pm2/ecosystem.config.js
@@ -1,7 +1,9 @@
+const pkg = require('../../package.json');
+
 module.exports = {
   apps: [
     {
-      name: 'bwb', // must match APP in scripts if you use pm2 commands by name
+      name: pkg.name.replace(/^@.*\//, ''), // must match APP in scripts if you use pm2 commands by name
       script: './bin/start',
       cwd: '.',
       instances: 1, // set to 2 or 'max' for zero-downtime reloads
@@ -10,8 +12,8 @@ module.exports = {
       env: {
         NODE_ENV: 'production',
       },
-      out_file: '/var/log/bwb/out.log',
-      error_file: '/var/log/bwb/err.log',
+      out_file: `/var/log/${pkg.name.replace(/^@.*\//, '')}/out.log`,
+      error_file: `/var/log/${pkg.name.replace(/^@.*\//, '')}/err.log`,
       merge_logs: true,
       log_date_format: 'YYYY-MM-DD HH:mm:ss',
     },


### PR DESCRIPTION
Update .gitignore and PM2 configuration to dynamically use the package name for better generalization and correct file ignoring.

---
<a href="https://cursor.com/background-agent?bcId=bc-794ea197-704a-4a7f-a9ef-1cbf98c9730d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-794ea197-704a-4a7f-a9ef-1cbf98c9730d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

