### PR TITLE
Fix typescript errors for vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "jsonwebtoken": "^9.0.2",
     "prisma": "^5.17.0",
     "resend": "^3.5.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/node": "^20.14.12"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.6",
-    "@types/node": "^20.14.12",
     "dotenv-cli": "^7.4.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.5.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     "rootDir": "src",                                    /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -106,9 +106,10 @@
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  },
-  "include": ["src/**/*.ts"]
-}
+        /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
+      "types": ["node", "jsonwebtoken"]
+    },
+    "include": ["src/**/*.ts"]
+  }


### PR DESCRIPTION
Fixes Vercel deployment errors by configuring TypeScript to correctly resolve Node.js and jsonwebtoken types.

The errors indicated missing type declarations for Node.js globals (like `console`, `process`, `require`) and the `jsonwebtoken` module during Vercel's build. This PR resolves these by updating `tsconfig.json` to include `node` module resolution and `node`/`jsonwebtoken` types, and by moving the corresponding `@types` packages to `dependencies` to ensure they are installed in the Vercel environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f0cfa65-0a4f-45f2-af46-9ab64d0bc9c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f0cfa65-0a4f-45f2-af46-9ab64d0bc9c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

