### PR TITLE
Investigate database connection failure for login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tobenot/basic-web-game-backend-contract",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tobenot/basic-web-game-backend-contract",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
         "@fastify/cors": "^11.1.0",
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "prisma": "^5.17.0",
         "resend": "^3.5.0",
+        "undici": "^6.19.8",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -28,7 +29,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "18.x"
       },
       "peerDependencies": {
         "@trpc/server": "^11.4.3",
@@ -2721,6 +2722,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "ISC",
   "type": "commonjs",
   "engines": {
-    "node": ">=18"
+    "node": "18.x"
   },
   "bugs": {
     "url": "https://github.com/tobenot/Basic-Web-Game-Backend/issues"
@@ -58,7 +58,6 @@
     "fastify": "^5.4.0",
     "jsonwebtoken": "^9.0.2",
     "undici": "^6.19.8",
-    "undici-proxy-agent": "^7.0.0",
     "prisma": "^5.17.0",
     "resend": "^3.5.0",
     "zod": "^3.23.8"

--- a/src/framework/utils/http-proxy.ts
+++ b/src/framework/utils/http-proxy.ts
@@ -1,5 +1,4 @@
-import { setGlobalDispatcher } from 'undici';
-import { ProxyAgent } from 'undici-proxy-agent';
+import { setGlobalDispatcher, ProxyAgent } from 'undici';
 
 export function setupGlobalHttpProxyFromEnv() {
 	const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.GLOBAL_HTTP_PROXY;


### PR DESCRIPTION
Fix Vercel build error by removing `undici-proxy-agent` and using `undici`'s built-in `ProxyAgent`.

The `undici-proxy-agent` package was not found in the npm registry during Vercel deployment, causing the build to fail with a 404 error. This change replaces the external dependency with `ProxyAgent` directly from `undici` (which now includes this functionality) and pins the Node.js version to `18.x` to address a Vercel warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba525988-0368-47fb-9bd1-77855eaffa51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba525988-0368-47fb-9bd1-77855eaffa51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

