### PR TITLE
Fix typescript errors for vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,14 +62,14 @@
     "resend": "^3.5.0",
     "zod": "^3.23.8",
     "dotenv-cli": "^7.4.4",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@trpc/server": "^11.4.3"
   },
   "peerDependencies": {
     "@trpc/server": "^11.4.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@trpc/server": "^11.4.3",
     "archiver": "^6.0.1",
     "ts-node-dev": "^2.0.0"
   }

--- a/src/framework/routers/auth.ts
+++ b/src/framework/routers/auth.ts
@@ -39,7 +39,8 @@ export const authRouter = router({
 
 	requestLoginLink: publicProcedure
 		.input(z.object({ email: z.string().email() }))
-		.mutation(async ({ input: { email } }) => {
+		.mutation(async ({ input }: { input: { email: string } }) => {
+			const { email } = input;
 			const user = await prisma.user.upsert({
 				where: { email },
 				update: {},
@@ -81,7 +82,7 @@ export const authRouter = router({
 
 	verifyMagicToken: publicProcedure
 		.input(z.object({ token: z.string() }))
-		.query(async ({ input }) => {
+		.query(async ({ input }: { input: { token: string } }) => {
 			const hashedToken = createHash('sha256').update(input.token).digest('hex');
 			const authToken = await prisma.authToken.findUnique({ where: { token: hashedToken } });
 			if (!authToken || new Date() > authToken.expiresAt) {

--- a/src/framework/routers/cors-debug.ts
+++ b/src/framework/routers/cors-debug.ts
@@ -18,7 +18,7 @@ export const corsDebugRouter = router({
 
 	testOrigin: publicProcedure
 		.input(z.object({ origin: z.string() }))
-		.query(({ input }) => {
+		.query(({ input }: { input: { origin: string } }) => {
 			const corsConfig = getCorsConfig();
 			const allowed = isOriginAllowed(input.origin, corsConfig);
 			return {
@@ -38,7 +38,7 @@ export const corsDebugRouter = router({
 			method: z.string().optional(),
 			headers: z.array(z.string()).optional()
 		}))
-		.query(({ input }) => {
+		.query(({ input }: { input: { origin: string; method?: string; headers?: string[] } }) => {
 			const corsConfig = getCorsConfig();
 			const originAllowed = isOriginAllowed(input.origin, corsConfig);
 			return {

--- a/src/framework/routers/echo.ts
+++ b/src/framework/routers/echo.ts
@@ -13,7 +13,7 @@ const inputSchema = z.object({
 export const echoRouter = router({
 	echo: publicProcedure
 		.input(inputSchema)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input }: { input: z.infer<typeof inputSchema> }) => {
 			return {
 				message: input.message,
 				messageLength: input.message.length,


### PR DESCRIPTION
Fix Vercel deployment by ensuring `@trpc/server` is a runtime dependency and resolving implicit `any` TypeScript errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-538bceaf-fe15-4636-a60f-a9d36b9ae917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-538bceaf-fe15-4636-a60f-a9d36b9ae917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

