### PR TITLE
Run prisma generate on vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   ],
   "scripts": {
     "prisma:generate:schema": "node scripts/generate-prisma-schema.js",
+    "prisma:generate:client": "npx prisma generate",
     "dev": "npx dotenv -e .env -- npm run prisma:generate:schema && ts-node-dev --inspect --respawn --transpile-only src/server.ts",
-    "build": "npx dotenv -e .env -- npm run prisma:generate:schema && tsc && npm run copy-templates",
+    "build": "npx dotenv -e .env -- npm run prisma:generate:schema && npm run prisma:generate:client && tsc && npm run copy-templates",
     "migrate:dev": "npx dotenv -e .env -- npm run prisma:generate:schema && npx prisma migrate dev",
     "migrate:prod": "npx dotenv -e .env.publish -- npm run prisma:generate:schema && npx prisma migrate deploy",
     "studio": "npx dotenv -e .env -- npm run prisma:generate:schema && npx prisma studio",
@@ -34,6 +35,7 @@
     "pack:linux:modules": "node scripts/pack.js linux modules",
     "pack:all": "node scripts/pack.js all full"
   },
+  "postinstall": "prisma generate",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tobenot/Basic-Web-Game-Backend.git"
@@ -52,13 +54,13 @@
   "dependencies": {
     "@fastify/cors": "^11.1.0",
     "@fastify/static": "^8.2.0",
-    "@prisma/client": "^5.17.0",
+    "@prisma/client": "5.22.0",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.14.12",
     "fastify": "^5.4.0",
     "jsonwebtoken": "^9.0.2",
     "undici": "^6.19.8",
-    "prisma": "^5.17.0",
+    "prisma": "5.22.0",
     "resend": "^3.5.0",
     "zod": "^3.23.8",
     "dotenv-cli": "^7.4.4",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/index.ts": {
-      "includeFiles": "{test.html,cors-test.html,src/templates/**}",
+      "includeFiles": "{test.html,cors-test.html,src/templates/**,prisma/schema.prisma,node_modules/.prisma/**,node_modules/@prisma/client/**}",
       "maxDuration": 60
     }
   },


### PR DESCRIPTION
Ensure Prisma Client is generated and included in Vercel deployments to resolve `PrismaClientInitializationError`.

Vercel's dependency caching can lead to an outdated Prisma Client if `prisma generate` is not explicitly run during the build process, as the auto-generation might be skipped. This PR adds the necessary steps to ensure the client is always up-to-date and correctly bundled.

---
<a href="https://cursor.com/background-agent?bcId=bc-e77e4599-9394-410b-8794-c901aef63af7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e77e4599-9394-410b-8794-c901aef63af7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

