### PR TITLE
Generate and deploy prisma schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "hooks:install": "bash scripts/install-git-hooks.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
     "vercel-build": "npm run build",
-    "vercel:build": "node scripts/generate-prisma-schema.js && npx prisma generate && (npm run migrate:deploy)",
+    "vercel:build": "node scripts/generate-prisma-schema.js && npx prisma generate",
     "pack:win": "node scripts/pack.js win full",
     "pack:win:server": "node scripts/pack.js win server",
     "pack:win:modules": "node scripts/pack.js win modules",


### PR DESCRIPTION
Remove Prisma migration from Vercel build script to prevent deployment hangs.

The `migrate:deploy` step was causing Vercel builds to hang, especially during initial Supabase database setup, as it's a long-running network operation and existing migrations might be incompatible. Migrations should be run manually or in a separate CI step, not during the Vercel build phase.

---
<a href="https://cursor.com/background-agent?bcId=bc-409cc2b3-ee5b-422f-ae37-acb1825d044d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-409cc2b3-ee5b-422f-ae37-acb1825d044d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

