### PR TITLE
Add verification code login option

### DIFF
--- a/AUTH_CONFIGURATION.md
+++ b/AUTH_CONFIGURATION.md
@@ -20,6 +20,24 @@ JWT_SECRET=your-secret-key-here
 JWT_EXPIRY=7d
 ```
 
+### 邮件登录（魔法链接 + 邮件验证码）
+```bash
+# 是否在同一封邮件内同时包含魔法链接与验证码 (默认: true)
+AUTH_DUAL_IN_ONE_EMAIL=true
+
+# 魔法链接有效期（秒）（默认: 900 = 15分钟）
+AUTH_MAGIC_TTL_SEC=900
+
+# 邮件验证码有效期（秒）（默认: 600 = 10分钟）
+AUTH_OTP_TTL_SEC=600
+
+# 邮件验证码长度（默认: 6）
+AUTH_OTP_LENGTH=6
+
+# 邮件验证码最大尝试次数（默认: 5）
+AUTH_OTP_MAX_ATTEMPTS=5
+```
+
 ## 配置示例
 
 ### 1. 完全关闭鉴权 (开发环境)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,13 @@ cp .env.example .env
 - `EMAIL_FROM`: 邮件发送地址（默认：noreply@sendmail.tobenot.top）
 - `EMAIL_FROM_NAME`: 邮件发件人显示名（默认：YourApp）
 
+#### 登录与验证码配置
+- `AUTH_DUAL_IN_ONE_EMAIL`: 是否在同一封邮件内同时包含魔法链接与验证码（默认：true）
+- `AUTH_MAGIC_TTL_SEC`: 魔法链接有效期（秒）（默认：900）
+- `AUTH_OTP_TTL_SEC`: 邮件验证码有效期（秒）（默认：600）
+- `AUTH_OTP_LENGTH`: 邮件验证码长度（默认：6）
+- `AUTH_OTP_MAX_ATTEMPTS`: 验证码最大尝试次数（默认：5）
+
 #### 数据库配置
 - `DATABASE_URL`: PostgreSQL数据库连接字符串
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   email      String      @unique
   createdAt  DateTime    @default(now())
   authTokens AuthToken[]
+  loginChallenges LoginChallenge[]
 }
 
 // 一次性登录令牌模型
@@ -30,4 +31,21 @@ model AuthToken {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   expiresAt DateTime
   createdAt DateTime @default(now())
+}
+
+// 邮件登录挑战（同时支持魔法链接与邮件验证码）
+model LoginChallenge {
+  id             String    @id @default(cuid())
+  userId         String
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  email          String
+  magicTokenHash String?
+  codeHash       String?
+  codeAttempts   Int       @default(0)
+  expiresAt      DateTime
+  consumedAt     DateTime?
+  createdAt      DateTime  @default(now())
+
+  @@index([email])
+  @@index([magicTokenHash])
 }

--- a/prisma/schema.prisma.template
+++ b/prisma/schema.prisma.template
@@ -20,6 +20,7 @@ model User {
   email      String      @unique
   createdAt  DateTime    @default(now())
   authTokens AuthToken[]
+  loginChallenges LoginChallenge[]
 }
 
 // 一次性登录令牌模型
@@ -30,4 +31,21 @@ model AuthToken {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   expiresAt DateTime
   createdAt DateTime @default(now())
+}
+
+// 邮件登录挑战（同时支持魔法链接与邮件验证码）
+model LoginChallenge {
+  id             String    @id @default(cuid())
+  userId         String
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  email          String
+  magicTokenHash String?
+  codeHash       String?
+  codeAttempts   Int       @default(0)
+  expiresAt      DateTime
+  consumedAt     DateTime?
+  createdAt      DateTime  @default(now())
+
+  @@index([email])
+  @@index([magicTokenHash])
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,20 @@ export const config = {
     from: process.env.EMAIL_FROM || 'noreply@sendmail.tobenot.top',
     fromName: process.env.EMAIL_FROM_NAME || 'YourApp',
   },
+
+  // 登录与验证码配置（可通过环境变量覆盖）
+  authFlow: {
+    // 单封邮件同时包含魔法链接与验证码
+    dualInOneEmail: process.env.AUTH_DUAL_IN_ONE_EMAIL !== 'false',
+    // 魔法链接有效期（秒）
+    magicLinkTtlSec: Number(process.env.AUTH_MAGIC_TTL_SEC || 15 * 60),
+    // 邮件验证码有效期（秒）
+    otpTtlSec: Number(process.env.AUTH_OTP_TTL_SEC || 10 * 60),
+    // 验证码长度
+    otpLength: Number(process.env.AUTH_OTP_LENGTH || 6),
+    // 验证码最大尝试次数
+    otpMaxAttempts: Number(process.env.AUTH_OTP_MAX_ATTEMPTS || 5),
+  },
   
   // 环境判断
   isProduction: process.env.NODE_ENV === 'production',

--- a/src/framework/routers/auth.ts
+++ b/src/framework/routers/auth.ts
@@ -7,6 +7,7 @@ import * as jwt from 'jsonwebtoken';
 import * as fs from 'fs';
 import * as path from 'path';
 import { config } from '../../config';
+import { getAuthConfig } from '../../config/auth';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -47,21 +48,49 @@ export const authRouter = router({
 				create: { email },
 			});
 
+			// Dual challenge: magic link + OTP
 			const rawToken = randomBytes(32).toString('hex');
-			const hashedToken = createHash('sha256').update(rawToken).digest('hex');
-			const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+			const magicTokenHash = createHash('sha256').update(rawToken).digest('hex');
 
-			await prisma.authToken.create({
-				data: { token: hashedToken, userId: user.id, expiresAt },
+			const otpLength = config.authFlow.otpLength;
+			const otpCode = generateNumericOtp(otpLength);
+			const codeHash = createHash('sha256').update(otpCode).digest('hex');
+
+			const magicTtlMs = config.authFlow.magicLinkTtlSec * 1000;
+			const otpTtlMs = config.authFlow.otpTtlSec * 1000;
+			const createdAt = new Date();
+			const expiresAt = new Date(createdAt.getTime() + Math.max(magicTtlMs, otpTtlMs));
+
+			const challenge = await prisma.loginChallenge.create({
+				data: {
+					userId: user.id,
+					email,
+					magicTokenHash,
+					codeHash,
+					expiresAt,
+				},
 			});
 
 			const magicLink = buildMagicLink(rawToken);
 
-			const emailHtml = emailTemplate.replace(/\{\{magicLink\}\}/g, magicLink);
-			const emailText = `请点击以下链接登录:\n${magicLink}\n\n如果按钮无法点击，请将链接复制到浏览器中打开。该链接15分钟内有效。`;
+			// Render email with both link and OTP
+			let emailHtml = emailTemplate.replace(/\{\{magicLink\}\}/g, magicLink);
+			emailHtml = emailHtml.replace(/\{\{magicExpiryMinutes\}\}/g, `${Math.round(config.authFlow.magicLinkTtlSec / 60)}`);
+			emailHtml = emailHtml.replace(/\{\{otpCode\}\}/g, otpCode);
+			emailHtml = emailHtml.replace(/\{\{otpExpiryMinutes\}\}/g, `${Math.round(config.authFlow.otpTtlSec / 60)}`);
+
+			const emailText = [
+				`请点击以下链接登录:`,
+				magicLink,
+				'',
+				`或使用验证码登录（${Math.round(config.authFlow.otpTtlSec / 60)}分钟内有效）： ${otpCode}`,
+				'',
+				`如果按钮无法点击，请将链接复制到浏览器中打开。`
+			].join('\n');
 
 			if (!config.isProduction) {
 				console.log(`✨ Magic Link for ${email}: ${magicLink}`);
+				console.log(`🔢 OTP for ${email}: ${otpCode}`);
 			}
 
 			try {
@@ -77,25 +106,113 @@ export const authRouter = router({
 				console.error(`❌ Failed to send email to ${email}:`, emailError);
 			}
 
-			return { success: true };
+			return { success: true, challengeId: challenge.id };
 		}),
 
 	verifyMagicToken: publicProcedure
 		.input(z.object({ token: z.string() }))
 		.query(async ({ input }: { input: { token: string } }) => {
 			const hashedToken = createHash('sha256').update(input.token).digest('hex');
+
+			// Prefer new LoginChallenge flow
+			const challenge = await prisma.loginChallenge.findFirst({
+				where: { magicTokenHash: hashedToken },
+			});
+
+			const now = new Date();
+			const authCfg = getAuthConfig();
+
+			if (challenge) {
+				if (challenge.consumedAt) {
+					throw new Error('链接已被使用。');
+				}
+				// method-specific TTL check using createdAt + ttl
+				const createdAt = challenge.createdAt as unknown as Date;
+				const magicDeadline = new Date(createdAt.getTime() + config.authFlow.magicLinkTtlSec * 1000);
+				if (now > magicDeadline) {
+					throw new Error('链接无效或已过期。');
+				}
+
+				const sessionToken = jwt.sign(
+					{ userId: challenge.userId, amr: ['magic_link'] },
+					authCfg.jwtSecret as any,
+					{ expiresIn: authCfg.tokenExpiry as any }
+				);
+				await prisma.loginChallenge.update({
+					where: { id: challenge.id },
+					data: { consumedAt: new Date(), magicTokenHash: null, codeHash: null },
+				});
+				return { sessionToken };
+			}
+
+			// Legacy fallback to AuthToken
 			const authToken = await prisma.authToken.findUnique({ where: { token: hashedToken } });
 			if (!authToken || new Date() > authToken.expiresAt) {
 				throw new Error('链接无效或已过期。');
 			}
 			const sessionToken = jwt.sign(
-				{ userId: authToken.userId },
-				process.env.JWT_SECRET!,
-				{ expiresIn: '7d' }
+				{ userId: authToken.userId, amr: ['magic_link'] },
+				authCfg.jwtSecret as any,
+				{ expiresIn: authCfg.tokenExpiry as any }
 			);
 			await prisma.authToken.delete({ where: { id: authToken.id } });
 			return { sessionToken };
 		}),
+
+	verifyEmailCode: publicProcedure
+		.input(z.object({ challengeId: z.string(), code: z.string().min(4).max(12) }))
+		.mutation(async ({ input }: { input: { challengeId: string; code: string } }) => {
+			const { challengeId, code } = input;
+			const challenge = await prisma.loginChallenge.findUnique({ where: { id: challengeId } });
+			if (!challenge) {
+				throw new Error('验证码无效或已过期。');
+			}
+			if (challenge.consumedAt) {
+				throw new Error('该登录请求已被使用。');
+			}
+
+			const now = new Date();
+			const createdAt = challenge.createdAt as unknown as Date;
+			const otpDeadline = new Date(createdAt.getTime() + config.authFlow.otpTtlSec * 1000);
+			if (now > otpDeadline) {
+				throw new Error('验证码已过期。');
+			}
+
+			if ((challenge.codeAttempts || 0) >= config.authFlow.otpMaxAttempts) {
+				throw new Error('尝试次数过多，请重新请求验证码。');
+			}
+
+			const providedHash = createHash('sha256').update(code).digest('hex');
+			if (!challenge.codeHash || providedHash !== challenge.codeHash) {
+				await prisma.loginChallenge.update({
+					where: { id: challenge.id },
+					data: { codeAttempts: (challenge.codeAttempts || 0) + 1 },
+				});
+				throw new Error('验证码错误。');
+			}
+
+			const authCfg = getAuthConfig();
+			const sessionToken = jwt.sign(
+				{ userId: challenge.userId, amr: ['otp'] },
+				authCfg.jwtSecret as any,
+				{ expiresIn: authCfg.tokenExpiry as any }
+			);
+
+			await prisma.loginChallenge.update({
+				where: { id: challenge.id },
+				data: { consumedAt: new Date(), codeHash: null, magicTokenHash: null },
+			});
+
+			return { sessionToken };
+		}),
 });
 
-
+function generateNumericOtp(length: number): string {
+	const digits = '0123456789';
+	let otp = '';
+	const bytes = randomBytes(length);
+	for (let i = 0; i < length; i++) {
+		otp += digits[bytes[i] % 10];
+	}
+	return otp;
+}

--- a/src/framework/templates/magic-link-email.html
+++ b/src/framework/templates/magic-link-email.html
@@ -33,7 +33,7 @@
         </div>
         <div class="content">
             <p>您好！</p>
-            <p>我们已收到您的登录请求。请点击下方按钮直接安全登录您的账户：</p>
+            <p>我们已收到您的登录请求。请点击下方按钮直接安全登录您的账户，或使用下方验证码登录：</p>
             <div class="login-button-container">
                 <a href="{{magicLink}}" class="login-button">立即登录</a>
             </div>
@@ -46,7 +46,13 @@
                     <circle cx="12" cy="12" r="10"></circle>
                     <polyline points="12 6 12 12 16 14"></polyline>
                 </svg>
-                此链接将在15分钟后失效
+                链接有效期：{{magicExpiryMinutes}} 分钟
+            </div>
+
+            <div style="margin-top:24px; padding:16px; background:#f6fbf5; border:1px dashed #cde6cd; border-radius:8px;">
+                <p style="margin-bottom:8px; color:#2E7D32; font-weight:600;">或使用验证码登录：</p>
+                <div style="font-size:28px; letter-spacing:6px; font-weight:700; color:#2E7D32; text-align:center;">{{otpCode}}</div>
+                <p style="margin-top:8px; color:#4a4a4a; font-size:14px; text-align:center;">验证码有效期：{{otpExpiryMinutes}} 分钟</p>
             </div>
             <p>如果您未请求登录，请忽略此邮件。您的账户安全对我们至关重要。</p>
             <div class="security-note">


### PR DESCRIPTION
Implement dual email login (magic link + OTP) in a single email to offer flexible and robust authentication.

This allows users to choose their preferred login method (direct link or code) from the same email, providing a convenient fallback if one method encounters issues (e.g., magic link blocked by email scanner or OTP mistyped).

---
<a href="https://cursor.com/background-agent?bcId=bc-cec4ffda-c020-469c-8914-67fd7800b5ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cec4ffda-c020-469c-8914-67fd7800b5ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

