### PR TITLE
Separate gemini thinking and content

### DIFF
--- a/src/framework/utils/gemini-client.ts
+++ b/src/framework/utils/gemini-client.ts
@@ -69,8 +69,20 @@ export class GeminiClient {
 		const created = Math.floor(Date.now() / 1000);
 		const choices: ChatCompletionResponse['choices'] = candidates.map((c, idx) => {
 			const parts: any[] = c?.content?.parts || [];
-			const text = parts.map(p => typeof p?.text === 'string' ? p.text : '').join('');
-			const reasoningContent = c?.reasoning_content || '';
+			let text = '';
+			let reasoningContent = '';
+			for (const p of parts) {
+				const partText = typeof p?.text === 'string' ? p.text : '';
+				const isThought = (p as any)?.thought === true || (p as any)?.inlineThought === true || (p as any)?.role === 'thought';
+				if (isThought) {
+					reasoningContent += partText;
+				} else {
+					text += partText;
+				}
+			}
+			if (!reasoningContent && typeof c?.reasoning_content === 'string') {
+				reasoningContent = c.reasoning_content as string;
+			}
 			let finish: string | null = null;
 			const fr = c?.finishReason;
 			if (typeof fr === 'string') finish = fr.toLowerCase();

--- a/src/framework/utils/llm-client.ts
+++ b/src/framework/utils/llm-client.ts
@@ -108,9 +108,9 @@ export class LlmClient {
 							try {
 								const json = JSON.parse(data);
 								const reasoning = json?.choices?.[0]?.delta?.reasoning_content;
-								if (typeof reasoning === 'string' && reasoning.length > 0) yield reasoning;
+								if (typeof reasoning === 'string' && reasoning.length > 0) yield JSON.stringify({ reasoning });
 								const content = json?.choices?.[0]?.delta?.content;
-								if (typeof content === 'string' && content.length > 0) yield content;
+								if (typeof content === 'string' && content.length > 0) yield JSON.stringify({ content });
 							} catch {}
 						}
 					}
@@ -126,9 +126,9 @@ export class LlmClient {
 				try {
 					const json = JSON.parse(data);
 					const reasoning = json?.choices?.[0]?.delta?.reasoning_content;
-					if (typeof reasoning === 'string' && reasoning.length > 0) yield reasoning;
+					if (typeof reasoning === 'string' && reasoning.length > 0) yield JSON.stringify({ reasoning });
 					const content = json?.choices?.[0]?.delta?.content;
-					if (typeof content === 'string' && content.length > 0) yield content;
+					if (typeof content === 'string' && content.length > 0) yield JSON.stringify({ content });
 				} catch {}
 			}
 		}


### PR DESCRIPTION
Separate Gemini streaming responses into distinct `reasoning_content` and `content` fields to enable independent display on the frontend.

Previously, all parts of the Gemini stream, including internal thoughts, were concatenated into the `content` field. This change parses Gemini's specific thought markers (e.g., `part.thought`, `inlineThought`, `role: 'thought'`) and `reasoning_content` fields to correctly split these streams, allowing the frontend to display the model's reasoning process and final answer separately.

---
<a href="https://cursor.com/background-agent?bcId=bc-62588148-f66a-414b-8aaf-5fe9ec55f1bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62588148-f66a-414b-8aaf-5fe9ec55f1bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

