### PR TITLE
Debug cors policy issue on self-hosted server

### DIFF
--- a/src/config/cors.ts
+++ b/src/config/cors.ts
@@ -52,7 +52,8 @@ export function getCorsConfig(): CorsConfig {
       'Accept',
       'Origin',
       'x-api-key',
-      'x-goog-api-key'
+      'x-goog-api-key',
+      'x-feature-password'
     ],
     credentials: true,
     maxAge: Number(process.env.CORS_MAX_AGE) || 86400, // 默认24小时


### PR DESCRIPTION
Add `x-feature-password` to allowed CORS headers.

Browsers were blocking POST requests due to a CORS preflight failure. The preflight requested the `x-feature-password` header, but it was not explicitly listed in the server's `Access-Control-Allow-Headers`, leading to the browser reporting missing CORS headers on the actual POST response.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd421cd8-0cd8-406f-9dc3-284ce5b3fc7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd421cd8-0cd8-406f-9dc3-284ce5b3fc7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

